### PR TITLE
根据边框样式自动确定是否使用皮肤内置标题栏

### DIFF
--- a/script/js_common/uihacks.js
+++ b/script/js_common/uihacks.js
@@ -7,7 +7,8 @@ var mouseInControl = false;
 
 function uiHacksInit() {
 	if (!uiHacks) return;
-	UIHacks.FrameStyle = 3;//noboarder
+	if (UIHacks.FrameStyle != 3) return;
+	//UIHacks.FrameStyle = 3;//noboarder
 	UIHacks.MainMenuState = 1;//hide
 	UIHacks.StatusBarState = 0;//hide
 	UIHacks.MoveStyle = 0;//caption only
@@ -20,6 +21,7 @@ function uiHacksInit() {
 
 function uiHacksResetCaption(){
 	if (!uiHacks) return;
+	if (UIHacks.FrameStyle != 3) return;
 	UIHacks.SetPseudoCaption(menubtnw, 0, ww - 3*topbtnw - menubtnw, topbarh);
 	if(UIHacks.MainWindowState == 2) UIHacks.DisableSizing = true; //maximized
 	else UIHacks.DisableSizing = false;

--- a/script/js_panels/base.js
+++ b/script/js_panels/base.js
@@ -198,10 +198,16 @@ function detect_video() {
 }
 
 function set_panel() {
-	var ph = win_y - topbarh;
+    var ph = win_y, y_offset = 0;
+    if (UIHacks?.FrameStyle == 3) {
+        ph -= topbarh;
+        y_offset = topbarh;
+    } else if (UIHacks?.MainMenuState != 0) {
+        setTimeout(function() {UIHacks.MainMenuState = 0;}, 100);
+    }
 	try{
 		if(active_p.Width != ww || active_p.Height != ph)
-		active_p.Move(0, topbarh, ww, ph);
+		active_p.Move(0, y_offset, ww, ph);
 	}catch(e){}
 }
 

--- a/script/js_panels/base.js
+++ b/script/js_panels/base.js
@@ -202,9 +202,7 @@ function set_panel() {
     if (UIHacks?.FrameStyle == 3) {
         ph -= topbarh;
         y_offset = topbarh;
-    } else if (UIHacks?.MainMenuState != 0) {
-        setTimeout(function() {UIHacks.MainMenuState = 0;}, 100);
-    }
+    } 
 	try{
 		if(active_p.Width != ww || active_p.Height != ph)
 		active_p.Move(0, y_offset, ww, ph);


### PR DESCRIPTION
隐藏边框时停靠侧边无法自动吸附，如果选择显示菜单栏则会在皮肤初始化时自动隐藏菜单
因此修改了判定方式，不再强制隐藏边框，而是根据边框样式自动判断是否使用皮肤的标题栏