### PR TITLE
快进/快退时更新进度条

### DIFF
--- a/script/js_panels/base.js
+++ b/script/js_panels/base.js
@@ -1069,6 +1069,10 @@ function on_playback_time(time) {
 	}
 }
 
+function on_playback_seek(time) {
+	on_playback_time(time);
+}
+
 function on_volume_change(v) {
 	VolumeBar.ChangeValue(vol2pos(v) | 0);
 }


### PR DESCRIPTION
修复 https://github.com/dream7180/foobox-cn/issues/396 提到的问题：用快捷键进行快进快退操作时，进度条没有及时更新。
故此做出修改，回调函数原来是每秒进行更新的，现在执行快进、快退操作时会手动调用回调函数更新进度条进度及时间信息。