### PR TITLE
修复播放列表布局与时间文本显示

### DIFF
--- a/script/js_panels/bottombar.js
+++ b/script/js_panels/bottombar.js
@@ -224,6 +224,26 @@ function TimeFmt(t) {
 	return zpad(h) + ":" + zpad(m) + ":" + zpad(s);
 }
 
+function refresh_time_text_layout() {
+	// 预留更宽的时间文本空间，避免手写体或比例字体把秒数挤成省略号。
+	var tmp_img = gdi.CreateImage(1, 1);
+	var gb = tmp_img.GetGraphics();
+	var next_width = Math.ceil(Math.max(
+		gb.CalcTextWidth("88:88:88", g_font),
+		gb.CalcTextWidth(PlaybackTimeText ? PlaybackTimeText.Text : "00:00:00", g_font),
+		gb.CalcTextWidth(PlaybackLengthText ? PlaybackLengthText.Text : "00:00:00", g_font)
+	) + z(8));
+	tmp_img.ReleaseGraphics(gb);
+
+	var layout_changed = (time_length !== next_width);
+	time_length = next_width;
+	if (layout_changed && ww && wh && PlaybackTimeText && PlaybackLengthText && PBPrevious && PBPlay && PBNext && PBStop && MuteBtn && PBOBtn && seekbar && VolumeBar) {
+		init_obj();
+		setSize();
+		window.Repaint();
+	}
+}
+
 function Format_hms(t) {
 	if (t=="?") return "00:00:00";
 	var hms;
@@ -317,6 +337,7 @@ function initbuttons(){
 	RBtnTips = new UITextView("", g_font, c_font, rc_txt);
 	PlaybackTimeText = new UITextView(track_time, g_font, c_font, rc_txt);
 	PlaybackLengthText = new UITextView(track_len, g_font, c_font, lc_txt);
+	refresh_time_text_layout();
 	PBOpen = new ButtonUI(img_open);
 	PBPrevious = new ButtonUI(img_previous);
 	PBPlay = new ButtonUI((fb.IsPlaying && !fb.IsPaused) ? img_pause : img_play);
@@ -939,7 +960,10 @@ function on_playback_new_track(info) {
 	if(info){
 		track_len = fb.TitleFormat("%length%").EvalWithMetadb(info);
 		track_len = Format_hms(track_len);
-		if(track_len) PlaybackLengthText.ChangeText(track_len);
+		if(track_len) {
+			PlaybackLengthText.ChangeText(track_len);
+			refresh_time_text_layout();
+		}
 	}
 }
 
@@ -952,6 +976,7 @@ function on_playback_stop(reason) {
 		PlaybackTimeText.ChangeText("00:00:00");
 		seekbar.MaxValue = 0;
 		seekbar.ChangeValue(0);
+		refresh_time_text_layout();
 	}
 }
 

--- a/script/js_panels/jsplaylist.js
+++ b/script/js_panels/jsplaylist.js
@@ -248,6 +248,9 @@ cGroup = {
 	count_minimum_pre: 0
 };
 
+// 关闭后，播放列表间距会保持固定，不会因为右侧面板或封面列宽变化而自动补空白行。
+var auto_minimum_rows_by_cover = window.GetProperty("*GROUP: Auto minimum rows follow cover width", false);
+
 cover = {
 	show: true,
 	keepaspectratio: window.GetProperty("CUSTOM.Cover keep ration aspect", true),
@@ -2593,7 +2596,7 @@ function reinit_config(){
 
 function get_grprow_minimum(column_w){
 	cGroup.count_minimum_pre = cGroup.count_minimum;
-	if (column_w > 0) {
+	if (auto_minimum_rows_by_cover && column_w > 0) {
 		cGroup.count_minimum = Math.ceil(column_w / cTrack.height);
 		if (cGroup.count_minimum < cGroup.default_count_minimum) cGroup.count_minimum = cGroup.default_count_minimum;
 	} else {

--- a/script/js_panels/jsplaylist/WSHplaylist.js
+++ b/script/js_panels/jsplaylist/WSHplaylist.js
@@ -74,6 +74,72 @@ oGroup = function(index, start, count, total_time_length, focusedTrackId, iscoll
 	}
 };
 
+function get_fixed_cover_rect(base_x, base_y, column_width, row_height) {
+	// 封面大小跟随单行高度，避免大封面把相邻条目压住。
+	var cover_side = Math.max(0, Math.min(column_width, row_height));
+	var inner_side = Math.max(0, cover_side - cover.margin * 2 - 1);
+	var offset_x = get_cover_left_padding(column_width, cover_side);
+	var offset_y = Math.max(0, Math.floor((row_height - cover_side) / 2));
+	return {
+		x: Math.floor(base_x + offset_x + cover.margin),
+		y: Math.floor(base_y + offset_y + cover.margin),
+		w: inner_side,
+		h: inner_side
+	};
+}
+
+function get_cover_left_padding(column_width, cover_side) {
+	// 左边距固定为 2 个缩放单位，列宽不足时自动收缩，避免坐标溢出。
+	return Math.max(0, Math.min(g_z2, column_width - cover_side));
+}
+
+function get_cover_content_x(base_x, column_width, row_height) {
+	if (column_width <= 0 || row_height <= 0) {
+		return Math.floor(base_x);
+	}
+	var cover_side = Math.max(0, Math.min(column_width, row_height));
+	var inner_side = Math.max(0, cover_side - cover.margin * 2 - 1);
+	var offset_x = get_cover_left_padding(column_width, cover_side);
+	var content_x = base_x + offset_x + cover.margin + inner_side;
+	return Math.floor(Math.max(base_x, Math.min(base_x + column_width, content_x)));
+}
+
+function get_cover_crop(img, dst_w, dst_h) {
+	// 保持目标区域尺寸不变，通过裁切源图来铺满方形封面区域。
+	var src_x = 1;
+	var src_y = 1;
+	var src_w = Math.max(1, img.Width - 2);
+	var src_h = Math.max(1, img.Height - 2);
+	if (!cover.keepaspectratio) {
+		return {
+			src_x: src_x,
+			src_y: src_y,
+			src_w: src_w,
+			src_h: src_h
+		};
+	}
+
+	var dst_ratio = dst_w / Math.max(1, dst_h);
+	var src_ratio = src_w / Math.max(1, src_h);
+	if (src_ratio > dst_ratio) {
+		var cropped_w = Math.floor(src_h * dst_ratio);
+		src_x += Math.max(0, Math.floor((src_w - cropped_w) / 2));
+		src_w = Math.max(1, cropped_w);
+	}
+	else if (src_ratio < dst_ratio) {
+		var cropped_h = Math.floor(src_w / dst_ratio);
+		src_y += Math.max(0, Math.floor((src_h - cropped_h) / 2));
+		src_h = Math.max(1, cropped_h);
+	}
+
+	return {
+		src_x: src_x,
+		src_y: src_y,
+		src_w: src_w,
+		src_h: src_h
+	};
+}
+
 oItem = function(playlist, row_index, type, handle, track_index, group_index, track_index_in_group, heightInRow, groupRowDelta, obj, empty_row_index) {
 	this.type = type;
 	this.playlist = playlist;
@@ -417,14 +483,14 @@ oItem = function(playlist, row_index, type, handle, track_index, group_index, tr
 			// ===============
 			if (p.headerBar.columns[0].w > 0) {
 				cover.w = p.headerBar.columns[0].w;
-				cover.h = cover.w;
+				cover.h = Math.min(cover.w, cTrack.height);
 			}
 			else {
 				cover.w = 0;
 				cover.h = 0;
 			};
-			var tcolumn_x = this.x + Math.floor(cover.w);
-			var line_width = this.w - cover.w + cScrollBar.width;
+			var tcolumn_x = get_cover_content_x(this.x, cover.w, Math.min(this.h, cTrack.height));
+			var line_width = this.w - Math.max(0, tcolumn_x - this.x) + cScrollBar.width;
 			if (this.empty_row_index == 0) {
 				this.queue_idx = plman.FindPlaybackQueueItemIndex(this.metadb, this.playlist, this.track_index) + 1;
 				if (fb.IsPlaying && plman.PlayingPlaylist == this.playlist && this.track_index == p.list.nowplaying.PlaylistItemIndex) {
@@ -484,10 +550,11 @@ oItem = function(playlist, row_index, type, handle, track_index, group_index, tr
 				};
 				if ((this.track_index_in_group == 0 || (this.row_index == 0 && cover_draw_delta > 0))) {
 					// cover bg
-					var cv_x = Math.floor(this.x);
-					var cv_y = Math.floor(this.y - cover_draw_delta);
-					var cv_w = Math.floor(cover.w);
-					var cv_h = Math.floor(cover.h);
+					var cover_rect = get_fixed_cover_rect(this.x, this.y - cover_draw_delta, cover.w, Math.min(this.h, cTrack.height));
+					var cv_x = cover_rect.x;
+					var cv_y = cover_rect.y;
+					var cv_w = cover_rect.w;
+					var cv_h = cover_rect.h;
 
 					if(p.list.groups[this.group_index].load_requested == 0)
 						p.list.groups[this.group_index].cover_img = g_image_cache.hit(this.group_index);
@@ -495,25 +562,8 @@ oItem = function(playlist, row_index, type, handle, track_index, group_index, tr
 					if (typeof p.list.groups[this.group_index].cover_img != "undefined") {
 						if (p.list.groups[this.group_index].cover_img == null) p.list.groups[this.group_index].cover_img = images.nocover;
 						if (p.list.groups[this.group_index].cover_img) {
-							if (cover.keepaspectratio) {
-								// *** check aspect ratio *** //
-								if (p.list.groups[this.group_index].cover_img.Height >= p.list.groups[this.group_index].cover_img.Width) {
-									var ratio = p.list.groups[this.group_index].cover_img.Width / p.list.groups[this.group_index].cover_img.Height;
-									var cv_offset = Math.floor((cv_h - cv_w * ratio) / 2);
-									cv_x += cv_offset;
-									cv_w = cv_w - cv_offset * 2 - 1;
-									cv_h = cv_h - 1;
-								}
-								else {
-									var ratio = p.list.groups[this.group_index].cover_img.Height / p.list.groups[this.group_index].cover_img.Width;
-									var cv_offset = Math.floor((cv_w - cv_h * ratio) / 2);
-									cv_y += cv_offset;
-									cv_w = cv_w - 1;
-									cv_h = cv_h - cv_offset * 2 - 1;
-								};
-								// *** check aspect ratio *** //
-							};
-							gr.DrawImage(p.list.groups[this.group_index].cover_img, cv_x, cv_y, cv_w, cv_h, 1, 1, p.list.groups[this.group_index].cover_img.Width-2, p.list.groups[this.group_index].cover_img.Height-2);
+							var cover_crop = get_cover_crop(p.list.groups[this.group_index].cover_img, cv_w, cv_h);
+							gr.DrawImage(p.list.groups[this.group_index].cover_img, cv_x, cv_y, cv_w, cv_h, cover_crop.src_x, cover_crop.src_y, cover_crop.src_w, cover_crop.src_h);
 						};
 					}
 					else {
@@ -541,11 +591,11 @@ oItem = function(playlist, row_index, type, handle, track_index, group_index, tr
 					if (g_dragndrop_status && dragndrop.drop_id == this.track_index && p.list.ishover && !g_dragndrop_bottom) {
 						if (!plman.IsPlaylistItemSelected(p.list.playlist, this.track_index)) {
 							if (this.track_index > dragndrop.drag_id) {
-								gr.FillSolidRect(tcolumn_x, this.cal_y1, this.w - cover.w, cList.borderWidth, g_color_normal_txt);
+								gr.FillSolidRect(tcolumn_x, this.cal_y1, line_width, cList.borderWidth, g_color_normal_txt);
 								//dragndrop.drop_id = this.track_index;
 							}
 							else if (this.track_index < dragndrop.drag_id) {
-								gr.FillSolidRect(tcolumn_x, this.y - cList.borderWidth_half, this.w - cover.w, cList.borderWidth, g_color_normal_txt);
+								gr.FillSolidRect(tcolumn_x, this.y - cList.borderWidth_half, line_width, cList.borderWidth, g_color_normal_txt);
 								//dragndrop.drop_id = this.track_index;
 							};
 						}
@@ -599,7 +649,7 @@ oItem = function(playlist, row_index, type, handle, track_index, group_index, tr
 			}
 			// Draw Header content
 			// ===================
-			var line_x = this.x + cover.w + g_z2;
+			var line_x = get_cover_content_x(this.x, cover.w, Math.min(this.h, cTrack.height)) + g_z2;
 			var vpadding = g_z3;
 			var l1_y = this.y - groupDelta;
 			var r1_w = gr.CalcTextWidth(this.r1, g_font_group1) + g_z10;
@@ -677,10 +727,11 @@ oItem = function(playlist, row_index, type, handle, track_index, group_index, tr
 				if (!p.headerBar.columns[0].w > 0 || (p.headerBar.columns[0].w > 0 && this.obj.collapsed)) {
 					if (this.heightInRow > 1 && cover.show) {
 						// cover bg
-						var cv_x = Math.floor(this.x + cover.margin);
-						var cv_y = Math.floor((this.y - groupDelta) + cover.margin + 1);
-						var cv_w = Math.floor(cover.w - cover.margin * 2);
-						var cv_h = Math.floor(cover.h - cover.margin * 2);
+						var cover_rect = get_fixed_cover_rect(this.x, this.y - groupDelta + 1, cover.w, Math.min(this.h, cTrack.height));
+						var cv_x = cover_rect.x;
+						var cv_y = cover_rect.y;
+						var cv_w = cover_rect.w;
+						var cv_h = cover_rect.h;
 						//
 						if(p.list.groups[this.group_index].load_requested == 0)
 							p.list.groups[this.group_index].cover_img = g_image_cache.hit(this.group_index);
@@ -688,25 +739,8 @@ oItem = function(playlist, row_index, type, handle, track_index, group_index, tr
 						if (typeof p.list.groups[this.group_index].cover_img != "undefined") {
 							if (p.list.groups[this.group_index].cover_img == null) p.list.groups[this.group_index].cover_img = images.nocover;
 							if (p.list.groups[this.group_index].cover_img) {
-								if (cover.keepaspectratio) {
-									// *** check aspect ratio *** //
-									if (p.list.groups[this.group_index].cover_img.Height >= p.list.groups[this.group_index].cover_img.Width) {
-										var ratio = p.list.groups[this.group_index].cover_img.Width / p.list.groups[this.group_index].cover_img.Height;
-										var cv_offset = Math.floor((cv_h - cv_w * ratio) / 2);
-										cv_x += cv_offset;
-										cv_w = cv_w - cv_offset * 2 - 1;
-										cv_h = cv_h - 1;
-									}
-									else {
-										var ratio = p.list.groups[this.group_index].cover_img.Height / p.list.groups[this.group_index].cover_img.Width;
-										var cv_offset = Math.floor((cv_w - cv_h * ratio) / 2);
-										cv_y += cv_offset;
-										cv_w = cv_w - 1;
-										cv_h = cv_h - cv_offset * 2 - 1;
-									};
-									// *** check aspect ratio *** //
-								};
-								gr.DrawImage(p.list.groups[this.group_index].cover_img, cv_x, cv_y, cv_w, cv_h, 1, 1, p.list.groups[this.group_index].cover_img.Width-2, p.list.groups[this.group_index].cover_img.Height-2);
+								var group_cover_crop = get_cover_crop(p.list.groups[this.group_index].cover_img, cv_w, cv_h);
+								gr.DrawImage(p.list.groups[this.group_index].cover_img, cv_x, cv_y, cv_w, cv_h, group_cover_crop.src_x, group_cover_crop.src_y, group_cover_crop.src_w, group_cover_crop.src_h);
 							};
 						}
 						else {
@@ -722,14 +756,16 @@ oItem = function(playlist, row_index, type, handle, track_index, group_index, tr
 				if (!properties.enableTouchControl) {
 					if (g_dragndrop_status && this.ishover && p.list.ishover && this.obj.collapsed) {
 						if (!plman.IsPlaylistItemSelected(plman.ActivePlaylist, this.track_index)) {
+							var group_drop_x = get_cover_content_x(this.x, cover.w, Math.min(this.h, cTrack.height));
+							var group_drop_w = this.w - Math.max(0, group_drop_x - this.x);
 							if (this.track_index <= dragndrop.drag_id  && !g_dragndrop_bottom) {
 								if (this.groupRowDelta == 0) {
-									gr.FillSolidRect(this.x, this.y - cList.borderWidth_half, this.w, cList.borderWidth, g_color_normal_txt);
+									gr.FillSolidRect(group_drop_x, this.y - cList.borderWidth_half, group_drop_w, cList.borderWidth, g_color_normal_txt);
 								}
 								//dragndrop.drop_id = this.track_index;
 							}
 							else {
-								gr.FillSolidRect(this.x, this.cal_y1, this.w, cList.borderWidth, g_color_normal_txt);
+								gr.FillSolidRect(group_drop_x, this.cal_y1, group_drop_w, cList.borderWidth, g_color_normal_txt);
 								dragndrop.drop_id = this.track_index + this.obj.count - 1;
 							};
 						}
@@ -745,13 +781,17 @@ oItem = function(playlist, row_index, type, handle, track_index, group_index, tr
 
 	this.dragndrop_check = function(x, y, id) {
 		var groupDelta = this.groupRowDelta * cTrack.height;
-		this.ishover = (x >= this.x + p.headerBar.columns[0].w * (1 - this.type) && x < this.x + this.w && y >= this.y && y < this.y + this.h - groupDelta);
+		var col_cover_w = (p.headerBar.columns[0].w > 0 ? p.headerBar.columns[0].w : 0);
+		var col_cover_x = get_cover_content_x(this.x, col_cover_w, Math.min(this.h, cTrack.height));
+		this.ishover = (x >= col_cover_x && x < this.x + this.w && y >= this.y && y < this.y + this.h - groupDelta);
 		if(this.ishover) dragndrop.drop_id = this.track_index;
 	};
 
 	this.check = function(event, x, y) {
 		var groupDelta = this.groupRowDelta * cTrack.height;
-		this.ishover = (x >= this.x && x < this.x + this.w && y >= this.y && y < this.y + this.h - groupDelta);
+		var col_cover_w = (p.headerBar.columns[0].w > 0 ? p.headerBar.columns[0].w : 0);
+		var col_cover_x = get_cover_content_x(this.x, col_cover_w, Math.min(this.h, cTrack.height));
+		this.ishover = (x >= col_cover_x && x < this.x + this.w && y >= this.y && y < this.y + this.h - groupDelta);
 
 		var prev_rating_hover = this.rating_hover;
 		var prev_l_rating = this.l_rating;
@@ -1961,8 +2001,10 @@ oList = function(object_name, playlist) {
 				var rx = this.items[rowId].x;
 				var ry = this.items[rowId].y;
 				var rw = this.items[rowId].w;
+				var drop_column_width = (p.headerBar.columns[0].w > 0 ? p.headerBar.columns[0].w : 0);
+				var drop_x = get_cover_content_x(rx, drop_column_width, Math.min(item_height, cTrack.height));
 
-				gr.FillSolidRect(rx, ry + item_height - cList.borderWidth_half * 2, rw, cList.borderWidth, g_color_normal_txt);
+				gr.FillSolidRect(drop_x, ry + item_height - cList.borderWidth_half * 2, rw - Math.max(0, drop_x - rx), cList.borderWidth, g_color_normal_txt);
 			};
 		}
 


### PR DESCRIPTION
# PR 草稿：修复播放列表布局与时间文本显示

> 适用分支：`pr/layout-fixes`
>
> 适用提交：`1d92016`

## 背景

我在自用 foobox 的过程中，自用主题遇到了一组彼此相关的播放列表显示问题。这些问题表面上看起来分散，但根因都集中在播放列表布局逻辑上：部分尺寸是跟随封面列宽动态变化的，而不是跟随实际行高或实际绘制区域约束。我将相关坐标和尺寸逻辑收敛到更稳定的规则上了，让播放列表在不同窗口宽度下都保持一致。

## 问题

1. 单曲或少曲目分组的视觉间距会随着右侧区域宽度变化
2. 播放列表封面列图片尺寸会随窗口缩放变化，出现重叠
3. 封面与选中条之间会出现一段随缩放变化的留白
4. 进度条左右两侧时间部分字体文本在部分宽度下会被折叠成 `00:00: ...`
5. 排序逻辑有概率出现上下两行歌曲间距过大

## 原因分析

1. 分组最少占用行数默认会跟随封面列宽联动，导致单曲专辑会被自动补空白行
2. 曲目行封面在绘制时缺少“以行高约束实际封面尺寸”的统一规则，竖图和列宽变化会把布局撑乱
3. 选中背景、拖拽落点、文本起点等位置，部分仍按整列宽度计算，而不是按封面实际右边缘计算
4. 底栏时间文本可用宽度不足，而且曲目切换后没有及时按新文本长度重算布局

## 本次修改

1. 为分组最少行数增加独立开关，默认不再跟随封面列宽自动放大
2. 将曲目封面约束为“以单行高度为上限的固定正方形”，避免图片重叠下一项
3. 将选中背景、分隔线、拖拽落点、鼠标命中起点、分组头文字起点统一改为按封面实际右边缘计算
4. 为底栏时间文本补充布局重算逻辑，在创建控件和曲目切换时重新分配文本宽度

## 对比图
<img width="1511" height="913" alt="image" src="https://github.com/user-attachments/assets/f8dd8a9d-08b5-448b-8fca-2143af3f5154" />
<img width="1616" height="96" alt="image" src="https://github.com/user-attachments/assets/a7254702-8c09-49b5-b473-b6eb7c1c00b1" />

### 优化后：
<img width="1646" height="902" alt="image" src="https://github.com/user-attachments/assets/eddae4e4-df14-40e7-b352-6b3a493de1c1" />



## 影响范围

1. `script/js_panels/jsplaylist.js`
2. `script/js_panels/jsplaylist/WSHplaylist.js`
3. `script/js_panels/bottombar.js`

主要影响播放列表、封面列绘制和底栏时间文本显示，不涉及音频播放逻辑、媒体库数据结构或外部组件协议。

## 验证

1. 播放列表在不同右侧面板宽度下，单曲专辑不再出现明显的额外空白行
2. 封面图按固定方形区域绘制，不再压住下一项
3. 选中条与封面之间不再出现由整列宽度带来的异常留白
4. 曲目切换后，底栏时间文本显示更稳定，减少 `:...` 截断
5. 已对相关脚本做静态语法检查，`node --check` 通过
